### PR TITLE
[bugfix/doc] Fix broken cross-reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ end
 
 ### Short Options
 
-A short option consists of a hyphen `-` followed by a single alphabetic character. Multiple short options can be clustered together without spaces. A short option will be `true` unless followed by an [operand](#operand) or if immediately adjacent to one or more non-alphabetic characters matching the regular expression <code>/!-@[-`{-~/</code>.
+A short option consists of a hyphen `-` followed by a single alphabetic character. Multiple short options can be clustered together without spaces. A short option will be `true` unless followed by an [operand](#operands) or if immediately adjacent to one or more non-alphabetic characters matching the regular expression <code>/!-@[-`{-~/</code>.
 
 ```console
 $ getopts -ab -c


### PR DESCRIPTION
Very minor fix. The section heading was`Operands` (plural), but the link pointed to a typo `#operand` (singular).